### PR TITLE
build: add repo field to manifest for release workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sherwinski/automated-release-npm.git"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
In hopes that it will hopefully fix the issue that ocurred on [this run](https://github.com/sherwinski/automated-release-npm/actions/runs/11602565660/job/32307828521)