### PR TITLE
fix: prevent automatically publishing major releases

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,11 +9,47 @@
       {
         "releaseRules": [
           {
+            "breaking": true,
+            "release": "minor"
+          },
+          {
+            "type": "feat",
+            "release": "minor"
+          },
+          {
+            "type": "fix",
+            "release": "patch"
+          },
+          {
             "type": "docs",
             "release": "patch"
           },
           {
-            "type": "deps",
+            "type": "perf",
+            "release": "patch"
+          },
+          {
+            "type": "refactor",
+            "release": "patch"
+          },
+          {
+            "type": "style",
+            "release": "patch"
+          },
+          {
+            "type": "test",
+            "release": "patch"
+          },
+          {
+            "type": "build",
+            "release": "patch"
+          },
+          {
+            "type": "ci",
+            "release": "patch"
+          },
+          {
+            "type": "chore",
             "scope": "deps",
             "release": "patch"
           }


### PR DESCRIPTION
Since new major versions can introduce breaking changes, and package versions can't be rolled back, some teams may prefer to manually release new major versions to prevent possible errors through automation.