### PR TITLE
fix: revert f17daf7

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -112,6 +112,12 @@
       }
     ],
     [
+      "@semantic-release/npm",
+      {
+        "pkgRoot": "."
+      }
+    ],
+    [
       "@semantic-release/git",
       {
         "assets": [
@@ -122,12 +128,6 @@
         "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes} [skip ci]"
       }
     ],
-    "@semantic-release/github",
-    [
-      "@semantic-release/npm",
-      {
-        "pkgRoot": "."
-      }
-    ]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
Moving the NPM publish step to the end of the workflow seems to prevent bumping the version in package.json