### PR TITLE
build: attempt to use autogenerated GitHub token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -25,7 +25,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |


### PR DESCRIPTION
Supposedly, each repo will autogenerate a token `GITHUB_TOKEN` to run actions scoped against the repo. This commit replaces references to follow the token naming convention, while also removing the token from the repository secret keys. This is to test the theory that the repo will generate one on its own

Source: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication